### PR TITLE
Add background stroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Custom component for lovelace which can be used as a card or an element on a pic
 | fill | string | Background color of circle | `rgba(255, 255, 255, .75)`
 | stroke_width | number | Width of circle value indication ring | `6`
 | stroke_color | hex code | Default stroke color | `#03a9f4`
+| stroke_bg_width | number | Width of background stroke | none
+| stroke_bg_color | hex code | Default stroke bg color | `#999999`
 | color_stops | object | Sensor value to color mapping (see below) | none
 | gradient | boolean | Whether to smoothly transition between color stops | `false`
 | units | string | Custom units of measurement | none

--- a/circle-sensor-card.js
+++ b/circle-sensor-card.js
@@ -21,7 +21,10 @@ class CircleSensorCard extends LitElement {
 
           .container {
             position: relative;
-            height: 100%;
+            height: ${config.style.height || '100%'};
+            width: ${config.style.width};
+            top: ${config.style.top};
+            left: ${config.style.left};
             display: flex;
             flex-direction: column;
           }

--- a/circle-sensor-card.js
+++ b/circle-sensor-card.js
@@ -62,6 +62,11 @@ class CircleSensorCard extends LitElement {
       </style>
       <div class="container" id="container" on-click="${() => this._click()}">
         <svg viewbox="0 0 200 200" id="svg">
+          <circle id="circlestrokebg" cx="50%" cy="50%" r="45%"
+            fill$="${config.fill || 'rgba(255, 255, 255, .75)'}"
+            stroke$="${config.stroke_bg_color || '#03a9f4'}"
+            stroke-width$="${config.stroke_bg_width}"
+            transform="rotate(-90 100 100)"/>
           <circle id="circle" cx="50%" cy="50%" r="45%"
             fill$="${config.fill || 'rgba(255, 255, 255, .75)'}"
             stroke$="${config.stroke_color || '#03a9f4'}"

--- a/circle-sensor-card.js
+++ b/circle-sensor-card.js
@@ -64,7 +64,7 @@ class CircleSensorCard extends LitElement {
         <svg viewbox="0 0 200 200" id="svg">
           <circle id="circlestrokebg" cx="50%" cy="50%" r="45%"
             fill$="${config.fill || 'rgba(255, 255, 255, .75)'}"
-            stroke$="${config.stroke_bg_color || '#03a9f4'}"
+            stroke$="${config.stroke_bg_color || '#999999'}"
             stroke-width$="${config.stroke_bg_width}"
             transform="rotate(-90 100 100)"/>
           <circle id="circle" cx="50%" cy="50%" r="45%"


### PR DESCRIPTION
Define `stroke_bg_color` for the background stroke color and `stroke_bg_width` for the background stroke width. To disable the background stroke set `stroke_bg_width ` to 0.

![image](https://user-images.githubusercontent.com/3695304/92223886-63384980-eea1-11ea-8acf-9bd008fdb06a.png)
